### PR TITLE
Fix for function creation in structure.sql

### DIFF
--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -53,6 +53,8 @@ module ClickhouseActiverecord
           next
         elsif sql =~ /^INSERT INTO/
           connection.do_execute(sql, nil, format: nil)
+        elsif sql =~ /^CREATE .*?FUNCTION/
+          connection.do_execute(sql, nil, format: nil)
         else
           connection.execute(sql)
         end


### PR DESCRIPTION
I'm getting this error if structure.sql has function creations. This fixes it.

It automatically adds `FORMAT JSONCompact` at the end of the sql, and that fails:
```
ActiveRecord::StatementInvalid: ActiveRecord::ActiveRecordError: Response code: 400:
Code: 62. DB::Exception: Syntax error: failed at position 261 ('FORMAT') (line 7, col 2): FORMAT JSONCompact. Expected one of: token, Dot, OR, AND, IS NOT DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, end of query. (SYNTAX_ERROR) (version 23.9.6.20 (official build))
```