### PR TITLE
Preserve newlines in function definitions

### DIFF
--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -37,7 +37,7 @@ module ClickhouseActiverecord
 
       File.open(args.first, 'w:utf-8') do |file|
         functions.each do |function|
-          file.puts function + ";\n\n"
+          file.puts function.gsub('\\n', "\n") + ";\n\n"
         end
         
         tables.each do |table|


### PR DESCRIPTION
- Preserve newlines in functions, such as inside `functionDocumentation` comments

I will PR this upstream as well.