### PR TITLE
Sort functions by name

### DIFF
--- a/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
+++ b/lib/active_record/connection_adapters/clickhouse/schema_statements.rb
@@ -45,7 +45,7 @@ module ActiveRecord
         end
 
         def functions
-          result = do_system_execute("SELECT name FROM system.functions WHERE origin = 'SQLUserDefined'")
+          result = do_system_execute("SELECT name FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")
           return [] if result.nil?
           result['data'].flatten
         end

--- a/lib/clickhouse-activerecord/tasks.rb
+++ b/lib/clickhouse-activerecord/tasks.rb
@@ -33,7 +33,7 @@ module ClickhouseActiverecord
 
     def structure_dump(*args)
       tables = connection.execute("SHOW TABLES FROM #{@configuration['database']}")['data'].flatten
-      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined'")['data'].flatten
+      functions = connection.execute("SELECT create_query FROM system.functions WHERE origin = 'SQLUserDefined' ORDER BY name")['data'].flatten
 
       File.open(args.first, 'w:utf-8') do |file|
         functions.each do |function|

--- a/spec/cases/migration_spec.rb
+++ b/spec/cases/migration_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe 'Migration', :migrations do
           migrations_dir = File.join(FIXTURES_PATH, 'migrations', 'plain_function_creation')
           quietly { ClickhouseActiverecord::MigrationContext.new(migrations_dir, model.connection.schema_migration).up }
 
-          expect(ActiveRecord::Base.connection.functions).to match_array(['some_fun'])
+          expect(ActiveRecord::Base.connection.functions).to match_array(['addFun', 'multFun'])
         end
       end
 

--- a/spec/fixtures/migrations/plain_function_creation/1_create_some_function.rb
+++ b/spec/fixtures/migrations/plain_function_creation/1_create_some_function.rb
@@ -3,7 +3,12 @@
 class CreateSomeFunction < ActiveRecord::Migration[5.0]
   def up
     sql = <<~SQL
-      CREATE FUNCTION some_fun AS (x,y) -> x + y
+      CREATE FUNCTION multFun AS (x,y) -> x * y
+    SQL
+    do_execute(sql, format: nil)
+    
+    sql = <<~SQL
+      CREATE FUNCTION addFun AS (x,y) -> x + y
     SQL
     do_execute(sql, format: nil)
   end


### PR DESCRIPTION
Current order is pseudo-random based on what order developer had in local setup.
Now it's sorted by name and it should avoid function orders changing in structure.sql all the time