### PR TITLE
Use a custom version

### DIFF
--- a/lib/clickhouse-activerecord/version.rb
+++ b/lib/clickhouse-activerecord/version.rb
@@ -1,3 +1,3 @@
 module ClickhouseActiverecord
-  VERSION = '0.6.1'
+  VERSION = '0.6.1.1'
 end


### PR DESCRIPTION
## Overview

Using a custom version to avoid conflicts with rubygems.org gem versions from upstream repo/gem.

CC @sensorsasha @DenisSychyov @ST-eugenekrivdyuk @IvanTakarlikov-st @felix-dumit 